### PR TITLE
reflect notification status .isNotifying back ... 

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -1376,7 +1376,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                     self.mock.connectionDelegate?.peripheral(self.mock,
                                     didUpdateNotificationStateFor: mockCharacteristic,
                                     error: nil)
-                  }
+                }
             }
         case .failure(let error):
             queue.asyncAfter(deadline: .now() + interval) { [weak self] in

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -1372,7 +1372,11 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                     self.delegate?.peripheral(self,
                                               didUpdateNotificationStateFor: characteristic,
                                               error: nil)
-                }
+                    mockCharacteristic.isNotifying = enabled
+                    self.mock.connectionDelegate?.peripheral(self.mock,
+                                    didUpdateNotificationStateFor: mockCharacteristic,
+                                    error: nil)
+                  }
             }
         case .failure(let error):
             queue.asyncAfter(deadline: .now() + interval) { [weak self] in
@@ -1380,6 +1384,9 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                     self.delegate?.peripheral(self,
                                               didUpdateNotificationStateFor: characteristic,
                                               error: error)
+                    self.mock.connectionDelegate?.peripheral(self.mock,
+                                    didUpdateNotificationStateFor: mockCharacteristic,
+                                    error: error)
                 }
             }
         }        

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
@@ -225,6 +225,10 @@ public protocol CBMPeripheralSpecDelegate {
                     didReceiveSetNotifyRequest enabled: Bool,
                     for characteristic: CBMCharacteristic)
         -> Result<Void, Error>
+  
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didUpdateNotificationStateFor characteristic: CBMCharacteristicMock,
+                    error: Error?)
 }
 
 public extension CBMPeripheralSpecDelegate {
@@ -374,4 +378,11 @@ public extension CBMPeripheralSpecDelegate {
         -> Result<Void, Error> {
             return peripheral(p, didReceiveSetNotifyRequest: enabled, for: characteristic as CBMCharacteristic)
     }
+  
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didUpdateNotificationStateFor characteristic: CBMCharacteristicMock,
+                    error: Error?) {
+        // Empty default implementation
+    }
+
 }

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
@@ -208,8 +208,8 @@ public protocol CBMPeripheralSpecDelegate {
                     data: Data)
         -> Result<Void, Error>
 
-    /// This method will be called when notifications or indications were enabled
-    /// or disabled on the given characteristic using a mock central manager.
+    /// This method will be called when client requested enabling or disabling notifications or
+    /// indications on the given characteristic using a mock central manager.
     /// - Parameters:
     ///   - peripheral: The target peripheral specification.
     ///   - enabled: Whether notifications or indications were enabled or disabled.
@@ -226,6 +226,12 @@ public protocol CBMPeripheralSpecDelegate {
                     for characteristic: CBMCharacteristic)
         -> Result<Void, Error>
   
+    /// This method will be called when notifications or indications were enabled
+    /// or disabled on the given characteristic using a mock central manager.
+    /// - Parameters:
+    ///   - peripheral: The target peripheral specification.
+    ///   - characteristic: The target characteristic.
+    ///   - error: 
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didUpdateNotificationStateFor characteristic: CBMCharacteristicMock,
                     error: Error?)


### PR DESCRIPTION
Reflect notification status `.isNotifying` back and make delegate `didUpdateNotificationStateFor` for mock implementation available.

When enabling a notification and sending data via `.simulateValueUpdate` the data is getting lost until the manager caught up with the enabling. Since the enabling is sent async with a delay to an internal queue it takes an uncertain time until data will be sent. The characteristics property `.isNotifying` is not updated in mock device implementation.

This fix implements a mock delegation `didUpdateNotoficationStateFor:` and updates `.isNotifying` property. 